### PR TITLE
[대출 상담 기능] 대출 상담 삭제 기능 구현

### DIFF
--- a/src/main/java/com/sol/loan/controller/CounselController.java
+++ b/src/main/java/com/sol/loan/controller/CounselController.java
@@ -28,4 +28,10 @@ public class CounselController extends AbstractController {
     public ResponseDTO<Response> update(@PathVariable Long counselId, @RequestBody Request request) {
         return ok(counselService.update(counselId, request));
     }
+
+    @DeleteMapping("/{counselId}")
+    public ResponseDTO<Response> delete(@PathVariable Long counselId) {
+        counselService.delete(counselId);
+        return ok();
+    }
 }

--- a/src/main/java/com/sol/loan/service/CounselService.java
+++ b/src/main/java/com/sol/loan/service/CounselService.java
@@ -10,4 +10,6 @@ public interface CounselService {
     Response get(Long counselId);
 
     Response update(Long counselId, Request request);
+
+    void delete(Long counselId);
 }

--- a/src/main/java/com/sol/loan/service/CounselServiceImpl.java
+++ b/src/main/java/com/sol/loan/service/CounselServiceImpl.java
@@ -57,4 +57,15 @@ public class CounselServiceImpl implements CounselService {
 
         return modelMapper.map(counsel, Response.class);
     }
+
+    @Override
+    public void delete(Long counselId) {
+        Counsel counsel = counselRepository.findById(counselId).orElseThrow(() -> {
+            throw new BaseException(ResultType.SYSTEM_ERROR);
+        });
+
+        counsel.setIsDeleted(true);
+
+        counselRepository.save(counsel);
+    }
 }

--- a/src/test/java/com/sol/loan/service/CounselServiceTest.java
+++ b/src/test/java/com/sol/loan/service/CounselServiceTest.java
@@ -126,4 +126,20 @@ class CounselServiceTest {
 
         Assertions.assertThrows(BaseException.class, () -> counselService.update(findId, request));
     }
+
+    @Test
+    void Should_DeleteCounselEntity_When_RequestDeleteExistCounselInfo() {
+        Long targetId = 1L;
+
+        Counsel entity = Counsel.builder()
+                .counselId(1L)
+                .build();
+
+        when(counselRepository.save(any(Counsel.class))).thenReturn(entity);
+        when(counselRepository.findById(targetId)).thenReturn(Optional.ofNullable(entity));
+
+        counselService.delete(targetId);
+
+        assertThat(entity.getIsDeleted()).isSameAs(true);
+    }
 }


### PR DESCRIPTION
soft delete 로 delete를 하기 때문에, delete 연산이 아닌 default 값인 false로 설정되어 있는`isDeleted` 필드 값을 true 로 설정한다.
조회할 때 `Counsel` entity에서 `@Where` 어노테이션을 사용해서 `isDeleted` 필드 값이 false 인 레코드 들만
조회하도록 설정했으므로, 삭제된 레코드는 조회가 안됨.

This closes #7 